### PR TITLE
build: cria automação para PR

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+# Gatilho disparado em toda criação de PR para a main ou para a next
+on:
+  pull_request:
+    branches: [main, next]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install
+        run: npm install
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Arquivo para criar automação do `npm run build` e `npm install` durante as PRs para evitar que erros no build sejam commitados.

**Revisão:**
- verificar se as [actions](https://github.com/animaliads/animalia-design-tokens/runs/2509308968?check_suite_focus=true) passaram corretamente