### PR TITLE
fix(letter-spacing): corrige os valores

### DIFF
--- a/src/typography/letter-spacing.json
+++ b/src/typography/letter-spacing.json
@@ -4,34 +4,34 @@
       "value": "auto"
     },
     "1": {
-      "value": "0.15em"
+      "value": "0.015em"
     },
     "2": {
-      "value": "0.25em"
+      "value": "0.025em"
     },
     "3": {
-      "value": "0.5em"
+      "value": "0.05em"
     },
     "4": {
-      "value": "1.25em"
+      "value": "0.075em"
     },
     "5": {
-      "value": "1.5em"
+      "value": "0.1em"
     },
     "neg-1": {
-      "value": "-0.15em"
+      "value": "-0.015em"
     },
     "neg-2": {
-      "value": "-0.25em"
+      "value": "-0.025em"
     },
     "neg-3": {
-      "value": "-0.5em"
+      "value": "-0.05em"
     },
     "neg-4": {
-      "value": "-1.25em"
+      "value": "-0.075em"
     },
     "neg-5": {
-      "value": "-1.5em"
+      "value": "-0.1em"
     }
   }
 }


### PR DESCRIPTION
### Correção dos valores do Letter spacing

Corrige valores do letter-spacing pois não estava com a conversão para "em" correta.
Por isso os valores tem que estar de acordo com o valor atualizado do handoff.

**Revisão:**
- abrir a aba "checks"
- clicar em "Artifacts"
- baixar o arquivo "dist" e validar se os valores estão de acordo com o handoff